### PR TITLE
fix: 修复未名市周任务问题

### DIFF
--- a/assets/resource/base/pipeline/未名市周任务.json
+++ b/assets/resource/base/pipeline/未名市周任务.json
@@ -140,12 +140,12 @@
             "[JumpBack]Flag_维护中央广场2",
             "[JumpBack]Flag_旅游地图2",
             "[JumpBack]Flag_潮流青年",
+            "[JumpBack]Flag_高价纪念品",
             "[JumpBack]Flag_打印文件1",
             "[JumpBack]Flag_打印文件2",
             "[JumpBack]Flag_暴力装修",
             "[JumpBack]Flag_收拾办公桌1",
             "[JumpBack]Flag_收拾办公桌2",
-            "[JumpBack]Flag_高价纪念品",
             "[JumpBack]Flag_帮忙送餐1",
             "[JumpBack]Flag_帮忙送餐2",
             "[JumpBack]Flag_饮品派送1",
@@ -1334,6 +1334,7 @@
     },
     "Click_老奶奶拍视频": {
         "recognition": "OCR",
+        "action": "Click",
         "expected": [
             "在老奶奶左边",
             "在老奶奶右边"
@@ -2414,11 +2415,13 @@
             20,
             20
         ],
-        "end_hold": 1000,
+        "end_hold": 1500,
         "timeout": 2000,
+        "post_wait_freezes": 2000,
         "next": [
             "[JumpBack]Click_对话框标识",
-            "Click_关闭未名市奖励弹窗"
+            "Click_关闭未名市奖励弹窗",
+            "Click_未名市任务"
         ]
     },
     "Flag_暴力装修": {


### PR DESCRIPTION
# Pull Request

提交前请阅读 [PR 规范](../docs/zh_cn/develop/pull_request_guidelines.md)。

## 关联 Issue

无。
需求来源：1. 未名市周任务中“收拾办公桌2”的判定点有一定随机性，概率造成周任务功能卡住。2. “歌舞未名”任务存在卡死问题。

## 变更摘要

1. 修改“收拾办公桌2”任务节点，增加延时。
2. 为“歌舞未名”相关节点增加点击动作。
3. 修改任务执行顺序

## 验证

- 这两个任务在本地测试可正常运行。

- [x] 我已阅读并遵守 [PR 规范](../docs/zh_cn/develop/pull_request_guidelines.md)

## 截图 / 日志 / 说明

- 周任务具有随机性，问题复现困难，开发与修复周期长。如有问题再修复。
